### PR TITLE
create oneOf validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ _⚠️  The values set has to be correctly typed but are **not** validated._
 
 ## 🔧 Custom validators
 
-By default, `valienv` only exports 4 validators: `str` (for `string`), `nbr` (for `number`), `bool` (for `boolean`) and `oneOf` (for union of strings).<br>
+By default, `valienv` only exports 3 validators: `str` (for `string`), `nbr` (for `number`) and `bool` (for `boolean`) and `oneOf`, a helper to create validators for union of string literals.<br>
 But it's very easy to write your own:
 
 ```ts

--- a/README.md
+++ b/README.md
@@ -20,12 +20,13 @@ This library exports a main function: `validateEnv`.<br>
 Using `validators`, you can parse, validate and type required environment variables (other variables will be excluded).
 
 ```ts
-import { bool, nbr, str, validateEnv } from "valienv";
+import { bool, nbr, oneOf, str, validateEnv } from "valienv";
 
 // with process.env = {
 //   ACCENT_COLOR: "#0099e5",
 //   TIMEOUT_MS: "5000",
 //   ENABLE_ANALYTICS: "true",
+//   NODE_ENV: "development",
 // }
 
 export const env = validateEnv({
@@ -35,6 +36,7 @@ export const env = validateEnv({
     ACCENT_COLOR: str,
     TIMEOUT_MS: nbr,
     ENABLE_ANALYTICS: bool,
+    NODE_ENV: oneOf("development", "test", "production"),
   },
 });
 
@@ -42,6 +44,7 @@ export const env = validateEnv({
 //   ACCENT_COLOR: string;
 //   TIMEOUT_MS: number;
 //   ENABLE_ANALYTICS: boolean;
+//   NODE_ENV: "development" | "test" | "production";
 // }>
 ```
 
@@ -104,7 +107,7 @@ _⚠️  The values set has to be correctly typed but are **not** validated._
 
 ## 🔧 Custom validators
 
-By default, `valienv` only exports 3 validators: `str` (for `string`), `nbr` (for `number`) and `bool` (for `boolean`).<br>
+By default, `valienv` only exports 4 validators: `str` (for `string`), `nbr` (for `number`), `bool` (for `boolean`) and `oneOf` (for union of strings).<br>
 But it's very easy to write your own:
 
 ```ts
@@ -142,7 +145,6 @@ import { validateEnv } from "valienv";
 
 // with process.env = {
 //   ETHEREUM_ADDRESS: "0xb794f5ea0ba39494ce839613fffba74279579268",
-//   NODE_ENV: "development",
 //   OPENED_COUNTRIES: "FR,BE,DE",
 // }
 
@@ -152,15 +154,6 @@ export const env = validateEnv({
     // inlined validators return types are correctly infered
     ETHEREUM_ADDRESS: (value) => {
       if (validator.isEthereumAddress(value)) {
-        return value;
-      }
-    },
-    NODE_ENV: (value) => {
-      if (
-        value === "development" ||
-        value === "test" ||
-        value === "production"
-      ) {
         return value;
       }
     },
@@ -176,7 +169,6 @@ export const env = validateEnv({
 
 // -> typeof env = Readonly<{
 //   ETHEREUM_ADDRESS: string;
-//   NODE_ENV: "development" | "production" | "test";
 //   OPENED_COUNTRIES: string[];
 // }>
 ```

--- a/__tests__/validateEnv.ts
+++ b/__tests__/validateEnv.ts
@@ -1,10 +1,11 @@
-import { bool, EnvValidationError, nbr, str, validateEnv } from "../src";
+import { bool, EnvValidationError, nbr, oneOf, str, validateEnv } from "../src";
 
 test("with valid input", () => {
   const input = {
     FOO: "foo",
     BAR: "42",
     BAZ: "true",
+    ENV: "development",
   };
 
   const output = validateEnv({
@@ -13,6 +14,7 @@ test("with valid input", () => {
       FOO: str,
       BAR: nbr,
       BAZ: bool,
+      ENV: oneOf("development", "production"),
     },
   });
 
@@ -20,6 +22,7 @@ test("with valid input", () => {
     FOO: "foo",
     BAR: 42,
     BAZ: true,
+    ENV: "development",
   });
 });
 
@@ -28,6 +31,7 @@ test("with valid input (as mixed literals)", () => {
     FOO: "foo",
     BAR: 42,
     BAZ: true,
+    ENV: "development",
   };
 
   const output = validateEnv({
@@ -36,6 +40,7 @@ test("with valid input (as mixed literals)", () => {
       FOO: str,
       BAR: nbr,
       BAZ: bool,
+      ENV: oneOf("development", "production"),
     },
   });
 
@@ -43,6 +48,7 @@ test("with valid input (as mixed literals)", () => {
     FOO: "foo",
     BAR: 42,
     BAZ: true,
+    ENV: "development",
   });
 });
 
@@ -70,6 +76,7 @@ test("with invalid env variables", () => {
     FOO: "foo",
     BAR: "bar",
     BAZ: "baz",
+    ENV: "dev",
   };
 
   try {
@@ -79,6 +86,7 @@ test("with invalid env variables", () => {
         FOO: str,
         BAR: nbr,
         BAZ: bool,
+        ENV: oneOf("development", "production"),
       },
     });
   } catch (error) {
@@ -87,6 +95,7 @@ test("with invalid env variables", () => {
     expect((error as EnvValidationError).invalidVariables).toEqual([
       "BAR",
       "BAZ",
+      "ENV",
     ]);
     expect((error as EnvValidationError).missingVariables).toEqual([]);
   }

--- a/src/validators.ts
+++ b/src/validators.ts
@@ -18,3 +18,12 @@ export const nbr: Validator<number> = (value) => {
 };
 
 export const str: Validator<string> = (value) => value;
+
+export const oneOf =
+  <T extends string>(values: Readonly<T[]>): Validator<T> =>
+  (value) => {
+    // @ts-expect-error
+    if (values.includes(value)) {
+      return value as T;
+    }
+  };

--- a/src/validators.ts
+++ b/src/validators.ts
@@ -20,10 +20,11 @@ export const nbr: Validator<number> = (value) => {
 export const str: Validator<string> = (value) => value;
 
 export const oneOf =
-  <T extends string>(values: Readonly<T[]>): Validator<T> =>
+  <T extends string>(...values: Readonly<T[]>): Validator<T> =>
   (value) => {
-    // @ts-expect-error
-    if (values.includes(value)) {
-      return value as T;
+    const result = values.find((item) => item === value);
+
+    if (typeof result !== "undefined") {
+      return result;
     }
   };


### PR DESCRIPTION
Hi @zoontek 

I'm currently using valienv on several apps and I've got a suggestion for a new validator named `oneOf`.  
The goal is making the following validation a little shorter and easier to write:
```typescript
export const env = validateEnv({
  env: process.env,
  validators: {
    NODE_ENV: (value) => {
      if (
        value === "development" ||
        value === "test" ||
        value === "production"
      ) {
        return value;
      }
    },
  },
});
```

Could be written like this:
```typescript
export const env = validateEnv({
  env: process.env,
  validators: {
    NODE_ENV: oneOf(['development', 'test', 'production'] as const),
  },
});
```

For now, I haven't written any test or updated the documentation because I prefer to have your opinion on the subject before taking more time on this PR. But if you think this validator is relevant, I can quickly add some tests and update the readme.