### PR TITLE
add details in error message

### DIFF
--- a/__tests__/customValidators.ts
+++ b/__tests__/customValidators.ts
@@ -72,6 +72,10 @@ test("with invalid input", () => {
   } catch (error) {
     expect(error).toBeInstanceOf(EnvValidationError);
 
+    const errorMessage = (error as EnvValidationError).message;
+    expect(errorMessage).toContain("Invalid variables: NODE_ENV, SERVER_PORT");
+    expect(errorMessage).toContain("Missing variables: USER_EMAIL, SERVER_URL");
+
     expect((error as EnvValidationError).invalidVariables).toEqual([
       "NODE_ENV",
       "SERVER_PORT",

--- a/src/error.ts
+++ b/src/error.ts
@@ -9,7 +9,21 @@ export class EnvValidationError extends Error {
     invalidVariables?: string[];
     missingVariables?: string[];
   }) {
-    super("Some environment variables cannot be validated");
+    const errorMessageLines = [
+      "Some environment variables cannot be validated",
+    ];
+    if (invalidVariables.length > 0) {
+      errorMessageLines.push(
+        `Invalid variables: ${invalidVariables.join(", ")}`,
+      );
+    }
+    if (missingVariables.length > 0) {
+      errorMessageLines.push(
+        `Missing variables: ${missingVariables.join(", ")}`,
+      );
+    }
+
+    super(errorMessageLines.join("\n"));
     Object.setPrototypeOf(this, EnvValidationError.prototype);
 
     this.name = this.constructor.name;


### PR DESCRIPTION
Hi @zoontek!

I hope everything is going well on your side.

For a few months I'm using more and more valienv for different projects (front end with Vite or NextJS, node js apps, ...).  
And when someone adds an environment variable, we often forget to put it in our CI for deployments or say to the rest of the team that they have to add an environment variable in their local environment.  
And currently we've got in the terminal just this error message: `Some environment variables cannot be validated`.  

Even if the problem comes from communication/organisation in my team, I think adding more details in error message could help to understand what's wrong without checking the file defining environment validation.  

So in this PR I added in the error message 2 lines:
- the first one with invalid variables
- the second one with missing variables

What do you think?